### PR TITLE
Fix crashes when settings.json contains comments or trailing commas

### DIFF
--- a/Flow.Plugin.VSCodeWorkspaces.csproj
+++ b/Flow.Plugin.VSCodeWorkspaces.csproj
@@ -13,6 +13,7 @@
 		<LangVersion>latest</LangVersion>
 		<Nullable>warnings</Nullable>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
 		<DebugSymbols>true</DebugSymbols>

--- a/RemoteMachinesHelper/VSCodeRemoteMachinesApi.cs
+++ b/RemoteMachinesHelper/VSCodeRemoteMachinesApi.cs
@@ -34,7 +34,11 @@ namespace Flow.Plugin.VSCodeWorkspaces.RemoteMachinesHelper
 
                         try
                         {
-                            JsonElement vscodeSettingsFile = JsonSerializer.Deserialize<JsonElement>(fileContent);
+                            JsonElement vscodeSettingsFile = JsonSerializer.Deserialize<JsonElement>(fileContent, new JsonSerializerOptions
+                            {
+                                AllowTrailingCommas = true,
+                                ReadCommentHandling = JsonCommentHandling.Skip,
+                            });
                             if (vscodeSettingsFile.TryGetProperty("remote.SSH.configFile", out var pathElement))
                             {
                                 var path = pathElement.GetString();

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "ActionKeyword": "{",
   "Name": "VS Code Workspaces",
   "Author": "ricardosantos9521",
-  "Version": "1.1.1",
+  "Version": "1.1.2",
   "Language": "csharp",
   "Website": "https://github.com/ricardosantos9521/PowerToys/",
   "ExecuteFileName": "Flow.Plugin.VSCodeWorkspaces.dll",


### PR DESCRIPTION
Two changes:

- [Handle comments and trailing commas in settings.json](https://github.com/xWTF/Flow.Plugin.VSCodeWorkspace/commit/4b95199a808e8b8c0ef181ca1dcac59265655182), VSCode itself allows us to add comments or trailing commas there, but System.Text.Json doesn't by default
- [Specify RuntimeIdentifier to copy win-x64 e_sqlite3.dll](https://github.com/xWTF/Flow.Plugin.VSCodeWorkspace/commit/c6078d2b074191bc3b4ecfb4ce22f997336e1f07), thus MSBuild will copy proper `e_sqlite3.dll` to the output folder, and won't create `runtime` folder on build. I ackknowledge you have specified the publish platform in workflow, this change intends to make development easier :D