### PR TITLE
Fix duplication when using custom workspaces

### DIFF
--- a/PathString.cs
+++ b/PathString.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace Flow.Plugin.VSCodeWorkspaces
+{
+    public readonly struct PathString : IEquatable<PathString>
+    {
+        public readonly string Value;
+
+        public PathString(string value) => Value = value;
+
+        // Better debugging experience :)
+        public override string ToString() => Value;
+
+        // Linq compoares HashCode first
+        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+        // Then IEquatable.Equals, follow MS best practice
+        // https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings?redirectedfrom=MSDN#:~:text=XML%20and%20HTTP.-,File%20paths.,-Registry%20keys%20and
+        public bool Equals(PathString other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+        // Default object.Equals, just in case
+        public override bool Equals(object other)
+        {
+            if (other is PathString ps)
+                return Equals(ps);
+            if (other is string s)
+                return string.Equals(Value, s, StringComparison.OrdinalIgnoreCase);
+            return base.Equals(other);
+        }
+
+        public static bool operator ==(PathString left, PathString right) => left.Equals(right);
+        public static bool operator !=(PathString left, PathString right) => !(left == right);
+
+        public static implicit operator string(PathString h) => h.Value;
+        public static implicit operator PathString(string s) => new(s);
+    }
+}

--- a/WorkspacesHelper/VSCodeWorkspace.cs
+++ b/WorkspacesHelper/VSCodeWorkspace.cs
@@ -10,11 +10,11 @@ namespace Flow.Plugin.VSCodeWorkspaces.WorkspacesHelper
 {
     public record VSCodeWorkspace
     {
-        public string Path { get; init; }
+        public PathString Path { get; init; }
 
-        public string RelativePath { get; init; }
+        public PathString RelativePath { get; init; }
 
-        public string FolderName { get; init; }
+        public PathString FolderName { get; init; }
 
         public string ExtraInfo { get; init; }
 
@@ -34,7 +34,6 @@ namespace Flow.Plugin.VSCodeWorkspaces.WorkspacesHelper
                 TypeWorkspace.DevContainer => Resources.TypeWorkspaceDevContainer,
                 _ => string.Empty
             };
-
         }
     }
 

--- a/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -37,7 +37,7 @@ namespace Flow.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                     return new VSCodeWorkspace()
                     {
-                        Path = uri,
+                        Path = unescapeUri,
                         RelativePath = typeWorkspace.Path,
                         FolderName = folderName,
                         ExtraInfo = typeWorkspace.MachineName,

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "ActionKeyword": "{",
   "Name": "VS Code Workspaces",
   "Author": "ricardosantos9521",
-  "Version": "1.2.1",
+  "Version": "1.2.2",
   "Language": "csharp",
   "Website": "https://github.com/ricardosantos9521/PowerToys/",
   "ExecuteFileName": "Flow.Plugin.VSCodeWorkspaces.dll",


### PR DESCRIPTION
Hi taooceros,
I've noticed that you did some refactor for VSCodeWorkspace, which is nice. But, the refactor leads to some duplication issue.

When a custom uri that **doesn't EXACTLY MATCH the uri VSC would generate** is set, take `C:/Foo/Bar` as an example:
- `VSCodeWorkspace.Path` for ou workspace object would be `file:///C:/Foo/Bar`
- But the VSC generated workspace object would have `file%3A///c%3A/Foo/Bar`
- And the `workspaces.Distinct()` call later fails to eliminate duplications

To get rid of this, I've created the `PathString` class following [MSDN best practice](https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings?redirectedfrom=MSDN#:~:text=XML%20and%20HTTP.-,File%20paths.,-Registry%20keys%20andA) for Path comparison, and replaced `Path`, `RelativePath`, `FolderName` type of `VSCodeWorkspace` record. Also, the Path property is set to unescaped uri instead of the original one.

Tested and works on my machine, no more duplications :)