### PR TITLE
Added new workspace shared storage lookup since vscode 1.118.0

### DIFF
--- a/VSCodeHelper/VSCodeInstance.cs
+++ b/VSCodeHelper/VSCodeInstance.cs
@@ -23,6 +23,8 @@ namespace Flow.Plugin.VSCodeWorkspaces.VSCodeHelper
 
         public string AppData { get; set; } = string.Empty;
 
+        public string SharedStorageDbPath { get; set; } = string.Empty;
+
         public ImageSource WorkspaceIcon() => WorkspaceIconBitMap;
 
         public ImageSource RemoteIcon() => RemoteIconBitMap;

--- a/VSCodeHelper/VSCodeInstances.cs
+++ b/VSCodeHelper/VSCodeInstances.cs
@@ -18,6 +18,7 @@ namespace Flow.Plugin.VSCodeWorkspaces.VSCodeHelper
         private static string _systemPath = string.Empty;
 
         private static readonly string _userAppDataPath = Environment.GetEnvironmentVariable("AppData");
+        private static readonly string _userProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
         public static List<VSCodeInstance> Instances { get; set; } = new();
 
@@ -130,6 +131,7 @@ namespace Flow.Plugin.VSCodeWorkspaces.VSCodeHelper
 
                 var portableData = Path.Join(iconPath, "data");
                 instance.AppData = Directory.Exists(portableData) ? Path.Join(portableData, "user-data") : Path.Combine(_userAppDataPath, version);
+                instance.SharedStorageDbPath = GetSharedStorageDbPath(version, iconPath, Directory.Exists(portableData));
                 var iconVSCode = Path.Join(iconPath, $"{version}.exe");
 
                 var bitmapIconVscode = Icon.ExtractAssociatedIcon(iconVSCode)?.ToBitmap();
@@ -145,6 +147,31 @@ namespace Flow.Plugin.VSCodeWorkspaces.VSCodeHelper
 
                 Instances.Add(instance);
             }
+        }
+
+        private static string GetSharedStorageDbPath(string version, string iconPath, bool isPortable)
+        {
+            if (isPortable)
+            {
+                return Path.Join(iconPath, "data-shared", "sharedStorage", "state.vscdb");
+            }
+
+            var sharedStorageDirectory = version switch
+            {
+                "Code" => ".vscode-shared",
+                "Code - Insiders" => ".vscode-insiders-shared",
+                "Code - Exploration" => ".vscode-exploration-shared",
+                "VSCodium" => ".vscodium-shared",
+                "VSCodium - Insiders" => ".vscodium-insiders-shared",
+                _ => string.Empty,
+            };
+
+            if (string.IsNullOrEmpty(sharedStorageDirectory))
+            {
+                return string.Empty;
+            }
+
+            return Path.Combine(_userProfilePath, sharedStorageDirectory, "sharedStorage", "state.vscdb");
         }
     }
 }

--- a/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -2,15 +2,16 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Flow.Launcher.Plugin;
+using Flow.Plugin.VSCodeWorkspaces.VSCodeHelper;
+using JetBrains.Annotations;
+using Microsoft.Data.Sqlite;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using Flow.Plugin.VSCodeWorkspaces.VSCodeHelper;
-using JetBrains.Annotations;
-using Microsoft.Data.Sqlite;
 
 namespace Flow.Plugin.VSCodeWorkspaces.WorkspacesHelper
 {
@@ -101,36 +102,57 @@ namespace Flow.Plugin.VSCodeWorkspaces.WorkspacesHelper
                     }
 
                     // for vscode v1.64.0 or later
-                    using var connection = new SqliteConnection(
-                        $"Data Source={vscodeInstance.AppData}/User/globalStorage/state.vscdb;mode=readonly;cache=shared;");
-                    connection.Open();
-                    var command = connection.CreateCommand();
-                    command.CommandText = "SELECT value FROM ItemTable where key = 'history.recentlyOpenedPathsList'";
-                    var result = command.ExecuteScalar();
-                    if (result != null)
+                    var vscode_storage_db = Path.Combine(vscodeInstance.AppData, "User/globalStorage/state.vscdb");
+
+                    // for vscode v1.118.0 or later
+                    var vscode_shared_storage_db = vscodeInstance.SharedStorageDbPath;
+
+                    var storageDbPaths = new[] { vscode_storage_db, vscode_shared_storage_db }
+                        .Where(filePath => !string.IsNullOrEmpty(filePath) && File.Exists(filePath))
+                        .Distinct(StringComparer.OrdinalIgnoreCase);
+
+                    foreach (var storageDbPath in storageDbPaths)
                     {
-                        using var historyDoc = JsonDocument.Parse(result.ToString()!);
-                        var root = historyDoc.RootElement;
-                        if (!root.TryGetProperty("entries", out var entries))
-                            continue;
-                        foreach (var entry in entries.EnumerateArray())
-                        {
-                            if (entry.TryGetProperty("folderUri", out var folderUri) &&
-                                ParseFolderEntry(folderUri, vscodeInstance, entry) is { } folderWorkspace)
-                            {
-                                results.Add(folderWorkspace);
-                            }
-                            else if (entry.TryGetProperty("workspace", out var workspaceInfo) &&
-                                     ParseWorkspaceEntry(workspaceInfo, vscodeInstance, entry) is { } workspace)
-                            {
-                                results.Add(workspace);
-                            }
-                        }
+                        var storageDbResults = GetWorkspacesInVscdb(vscodeInstance, storageDbPath);
+                        results.AddRange(storageDbResults);
                     }
                 }
 
                 return results;
             }
+        }
+
+        private List<VsCodeWorkspace> GetWorkspacesInVscdb(VSCodeInstance vscodeInstance, string filePath)
+        {
+            var dbFileResults = new List<VsCodeWorkspace>();
+            using var connection = new SqliteConnection(
+                        $"Data Source={filePath};mode=readonly;cache=shared;");
+            connection.Open();
+            var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM ItemTable where key = 'history.recentlyOpenedPathsList'";
+            var result = command.ExecuteScalar();
+            if (result != null)
+            {
+                using var historyDoc = JsonDocument.Parse(result.ToString()!);
+                var root = historyDoc.RootElement;
+                if (!root.TryGetProperty("entries", out var entries))
+                    return dbFileResults;
+                foreach (var entry in entries.EnumerateArray())
+                {
+                    if (entry.TryGetProperty("folderUri", out var folderUri) &&
+                        ParseFolderEntry(folderUri, vscodeInstance, entry) is { } folderWorkspace)
+                    {
+                        dbFileResults.Add(folderWorkspace);
+                    }
+                    else if (entry.TryGetProperty("workspace", out var workspaceInfo) &&
+                             ParseWorkspaceEntry(workspaceInfo, vscodeInstance, entry) is { } workspace)
+                    {
+                        dbFileResults.Add(workspace);
+                    }
+                }
+            }
+
+            return dbFileResults;
         }
 
         [CanBeNull]


### PR DESCRIPTION
Hi,
Since VSCode v1.118, the location for the `recentlyOpenedPathsList` changed again. This PR brings the new location for the `state.vscdb` where the entry is. This is mostly adapted from the original fix PR submitted in PowerToys.

I only tested it with the Code Stable version and it did bring back the workspaces in Flow.

Fixes #24 