### PR TITLE
Fix VSCode 1.118 shared storage compatibility

### DIFF
--- a/VSCodeHelper/VSCodeInstance.cs
+++ b/VSCodeHelper/VSCodeInstance.cs
@@ -23,6 +23,8 @@ namespace Flow.Plugin.VSCodeWorkspaces.VSCodeHelper
 
         public string AppData { get; set; } = string.Empty;
 
+        public string SharedStorageDbPath { get; set; } = string.Empty;
+
         public ImageSource WorkspaceIcon() => WorkspaceIconBitMap;
 
         public ImageSource RemoteIcon() => RemoteIconBitMap;

--- a/VSCodeHelper/VSCodeInstances.cs
+++ b/VSCodeHelper/VSCodeInstances.cs
@@ -19,6 +19,8 @@ namespace Flow.Plugin.VSCodeWorkspaces.VSCodeHelper
 
         private static readonly string _userAppDataPath = Environment.GetEnvironmentVariable("AppData");
 
+        private static readonly string _userProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
         public static List<VSCodeInstance> Instances { get; set; } = new();
 
         private static BitmapImage Bitmap2BitmapImage(Bitmap bitmap)
@@ -130,6 +132,7 @@ namespace Flow.Plugin.VSCodeWorkspaces.VSCodeHelper
 
                 var portableData = Path.Join(iconPath, "data");
                 instance.AppData = Directory.Exists(portableData) ? Path.Join(portableData, "user-data") : Path.Combine(_userAppDataPath, version);
+                instance.SharedStorageDbPath = GetSharedStorageDbPath(version, iconPath, Directory.Exists(portableData));
                 var iconVSCode = Path.Join(iconPath, $"{version}.exe");
 
                 var bitmapIconVscode = Icon.ExtractAssociatedIcon(iconVSCode)?.ToBitmap();
@@ -145,6 +148,29 @@ namespace Flow.Plugin.VSCodeWorkspaces.VSCodeHelper
 
                 Instances.Add(instance);
             }
+        }
+
+        private static string GetSharedStorageDbPath(string version, string iconPath, bool isPortable)
+        {
+            if (isPortable)
+            {
+                return Path.Join(iconPath, "data-shared", "sharedStorage", "state.vscdb");
+            }
+
+            var sharedStorageDirectory = version switch
+            {
+                "Code"                  => ".vscode-shared",
+                "Code - Insiders"       => ".vscode-insiders-shared",
+                "Code - Exploration"    => ".vscode-exploration-shared",
+                "VSCodium"              => ".vscodium-shared",
+                "VSCodium - Insiders"   => ".vscodium-insiders-shared",
+                _                       => string.Empty,
+            };
+
+            if (string.IsNullOrEmpty(sharedStorageDirectory))
+                return string.Empty;
+
+            return Path.Combine(_userProfilePath, sharedStorageDirectory, "sharedStorage", "state.vscdb");
         }
     }
 }

--- a/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -100,36 +100,57 @@ namespace Flow.Plugin.VSCodeWorkspaces.WorkspacesHelper
                         }
                     }
 
-                    // for vscode v1.64.0 or later
-                    using var connection = new SqliteConnection(
-                        $"Data Source={vscodeInstance.AppData}/User/globalStorage/state.vscdb;mode=readonly;cache=shared;");
-                    connection.Open();
-                    var command = connection.CreateCommand();
-                    command.CommandText = "SELECT value FROM ItemTable where key = 'history.recentlyOpenedPathsList'";
-                    var result = command.ExecuteScalar();
-                    if (result != null)
+                    // for vscode v1.64.0 or later (legacy globalStorage)
+                    // and vscode v1.118 or later (shared storage)
+                    var vscode_storage_db = Path.Combine(vscodeInstance.AppData, "User/globalStorage/state.vscdb");
+                    var vscode_shared_storage_db = vscodeInstance.SharedStorageDbPath;
+
+                    var storageDbPaths = new[] { vscode_storage_db, vscode_shared_storage_db }
+                        .Where(filePath => !string.IsNullOrEmpty(filePath))
+                        .Distinct(StringComparer.OrdinalIgnoreCase);
+
+                    foreach (var storageDbPath in storageDbPaths)
                     {
-                        using var historyDoc = JsonDocument.Parse(result.ToString()!);
-                        var root = historyDoc.RootElement;
-                        if (!root.TryGetProperty("entries", out var entries))
+                        if (!File.Exists(storageDbPath))
                             continue;
-                        foreach (var entry in entries.EnumerateArray())
+
+                        using var connection = new SqliteConnection(
+                            $"Data Source={storageDbPath};mode=readonly;cache=shared;");
+                        connection.Open();
+                        var command = connection.CreateCommand();
+                        command.CommandText = "SELECT value FROM ItemTable where key = 'history.recentlyOpenedPathsList'";
+                        var result = command.ExecuteScalar();
+                        if (result != null)
                         {
-                            if (entry.TryGetProperty("folderUri", out var folderUri) &&
-                                ParseFolderEntry(folderUri, vscodeInstance, entry) is { } folderWorkspace)
+                            using var historyDoc = JsonDocument.Parse(result.ToString()!);
+                            var root = historyDoc.RootElement;
+                            if (root.TryGetProperty("entries", out var entries))
                             {
-                                results.Add(folderWorkspace);
-                            }
-                            else if (entry.TryGetProperty("workspace", out var workspaceInfo) &&
-                                     ParseWorkspaceEntry(workspaceInfo, vscodeInstance, entry) is { } workspace)
-                            {
-                                results.Add(workspace);
+                                foreach (var entry in entries.EnumerateArray())
+                                {
+                                    if (entry.TryGetProperty("folderUri", out var folderUri) &&
+                                        ParseFolderEntry(folderUri, vscodeInstance, entry) is { } folderWorkspace)
+                                    {
+                                        results.Add(folderWorkspace);
+                                    }
+                                    else if (entry.TryGetProperty("workspace", out var workspaceInfo) &&
+                                             ParseWorkspaceEntry(workspaceInfo, vscodeInstance, entry) is { } workspace)
+                                    {
+                                        results.Add(workspace);
+                                    }
+                                }
                             }
                         }
                     }
                 }
 
-                return results;
+                return results
+                    .Where(workspace => workspace != null)
+                    .GroupBy(workspace =>
+                        $"{workspace.VSCodeInstance?.ExecutablePath ?? ""}|{workspace.WorkspaceType}|{workspace.Path}",
+                        StringComparer.OrdinalIgnoreCase)
+                    .Select(group => group.First())
+                    .ToList();
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes VSCode workspace discovery after VSCode 1.118 moved \history.recentlyOpenedPathsList\ from the legacy \globalStorage/state.vscdb\ to a new shared storage database.

The plugin now probes both the legacy and shared storage databases for all VSCode variants (Stable, Insiders, Exploration, VSCodium, VSCodium Insiders, and portable installs), then deduplicates results.

## Root Cause

In VSCode 1.118 (April 2026), the recently opened paths list was moved to shared storage:

| VSCode Variant | Shared DB Path |
|---|---|
| Stable | \%USERPROFILE%\\.vscode-shared\\sharedStorage\\state.vscdb\ |
| Insiders | \%USERPROFILE%\\.vscode-insiders-shared\\sharedStorage\\state.vscdb\ |
| Exploration | \%USERPROFILE%\\.vscode-exploration-shared\\sharedStorage\\state.vscdb\ |
| VSCodium | \%USERPROFILE%\\.vscodium-shared\\sharedStorage\\state.vscdb\ |
| VSCodium Insiders | \%USERPROFILE%\\.vscodium-insiders-shared\\sharedStorage\\state.vscdb\ |
| Portable | \<install>\\data-shared\\sharedStorage\\state.vscdb\ |

## Changes

- **VSCodeInstance.cs**: Added \SharedStorageDbPath\ property
- **VSCodeInstances.cs**: Added \GetSharedStorageDbPath()\ method to compute shared storage path
- **VSCodeWorkspacesApi.cs**: Query both legacy and shared storage DBs, then deduplicate results by (executable, workspace type, path)

## Backward Compatibility

- VSCode < 1.118: shared DB doesn't exist → \File.Exists\ skips it → behavior unchanged
- VSCode >= 1.118: legacy DB exists but key is empty → falls back to shared DB
- Transition period (just upgraded): both DBs queried → deduplication ensures clean results

## Verification

- ✅ Builds clean (\dotnet build\, 0 errors)
- ✅ Local SQLite verification: legacy DB returns no results for \history.recentlyOpenedPathsList\, shared DB returns 121 entries with identical JSON schema
- ✅ Based on Microsoft PowerToys PR [#47505](https://github.com/microsoft/PowerToys/pull/47505) which fixed the same issue upstream

Fixes #24